### PR TITLE
FREEPBX-13255: CallerIDLookup host field characters limit too low

### DIFF
--- a/install.php
+++ b/install.php
@@ -37,7 +37,7 @@ $cidlookup_cols = array(
 	),
 	"http_host" => array(
 		"type" => "string",
-		"length" => 30,
+		"length" => 100,
 		"notnull" => false
 	),
 	"http_port" => array(
@@ -47,12 +47,12 @@ $cidlookup_cols = array(
 	),
 	"http_username" => array(
 		"type" => "string",
-		"length" => 30,
+		"length" => 50,
 		"notnull" => false
 	),
 	"http_password" => array(
 		"type" => "string",
-		"length" => 30,
+		"length" => 50,
 		"notnull" => false
 	),
 	"http_path" => array(


### PR DESCRIPTION
Changed http field limits for host (30->100), username (30->50) and password (30->50).

Reason:
The host field for adding a CallerID Lookup source is limited to 30 characters. This is too short for some domains (e.g. if you need to enter them with subdomains), which prevents using this module.
