### PR TITLE
FREEPBX-13576 add missing db fields

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -361,7 +361,7 @@ function cidlookup_add($post){
 	$mysql_charset = $db->escapeSimple($post['mysql_charset']);
 	$opencnam_account_sid = $db->escapeSimple($post['opencnam_account_sid']);
 	$opencnam_auth_token = $db->escapeSimple($post['opencnam_auth_token']);
-	$cm_group = $db->escapeSimple(implode('_',$post['cm_group']));
+	$cm_group = $db->escapeSimple(implode('_',$post['cm_group']?$post['cm_group']:array()));
 	$cm_format = $db->escapeSimple($post['cm_format']);
 	$cache = isset($post['cache']) ? $db->escapeSimple($post['cache']) : 0;
 	$results = sql("
@@ -392,7 +392,7 @@ function cidlookup_edit($id,$post){
 	$mysql_charset = $db->escapeSimple($post['mysql_charset']);
 	$opencnam_account_sid = $db->escapeSimple($post['opencnam_account_sid']);
 	$opencnam_auth_token =	$db->escapeSimple($post['opencnam_auth_token']);
-	$cm_group =	$db->escapeSimple(implode('_',$post['cm_group']));
+	$cm_group =	$db->escapeSimple(implode('_',$post['cm_group']?$post['cm_group']:array()));
 	$cm_format =	$db->escapeSimple($post['cm_format']);
 	$cache	= isset($post['cache'])?$db->escapeSimple($post['cache']):1;
 

--- a/install.php
+++ b/install.php
@@ -103,6 +103,18 @@ $cidlookup_cols = array(
 		"type" => "string",
 		"length" => 34,
 		"notnull" => false
+	),
+	"cm_group" => array(
+		"type" => "string",
+		"length" => 5,
+		"notnull" => false,
+		"default" => ''
+	),
+	"cm_format" => array(
+		"type" => "string",
+		"length" => 5,
+		"notnull" => false,
+		"default" => ''
 	)
 );
 outn(_("Processing Database Tables"));


### PR DESCRIPTION
Fields addedd:
- cm_group
- cm_format

Fields have been removed in commit:
f519be81624d162c7594e6f087fa33c8f1d7eed9

FREEPX  issue: http://issues.freepbx.org/browse/FREEPBX-13576